### PR TITLE
Deploy to DigitalOcean from CI workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -21,6 +21,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image
+        id: push
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -29,3 +30,11 @@ jobs:
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/chat-book-site-api:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/chat-book-site-api:${{ github.sha }}
+
+      - name: Deploy the app
+        uses: digitalocean/app_action/deploy@v2
+        env:
+          SAMPLE_DIGEST: ${{ steps.push.outputs.digest }}
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          app_id: ${{ secrets.DIGITALOCEAN_APP_ID }}


### PR DESCRIPTION
## Summary
- Captures the Docker build digest by adding `id: push` to the build-and-push step.
- Adds a DigitalOcean App Platform deployment step after the Docker image is pushed.
- Uses repository secrets for the DigitalOcean token and app id.

## Required secrets
- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN`
- `DIGITALOCEAN_ACCESS_TOKEN`
- `DIGITALOCEAN_APP_ID`

## Testing
- Not run locally; this change updates the GitHub Actions workflow only.