### PR TITLE
Rename Eli Himi branding to Learning Hub

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>EliGPT</title>
+    <title>Learning Hub</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/ui/AppHeader.jsx
+++ b/src/ui/AppHeader.jsx
@@ -131,10 +131,10 @@ export default function AppHeader({ isOpen, onToggle, onClose }) {
   return (
     <>
       <header className="app-header">
-        <NavLink className="app-brand" to="/" aria-label="Eli Himi workspace home" onClick={onClose}>
-          <span className="app-brand__mark" aria-hidden="true">EH</span>
+        <NavLink className="app-brand" to="/" aria-label="Learning Hub workspace home" onClick={onClose}>
+          <span className="app-brand__mark" aria-hidden="true">LH</span>
           <span className="app-brand__copy">
-            <strong>Eli Himi</strong>
+            <strong>Learning Hub</strong>
             <span>Learning workspace</span>
           </span>
         </NavLink>


### PR DESCRIPTION
## Summary
- Rename the visible app header branding from `Eli Himi` to `Learning Hub`
- Update the brand mark from `EH` to `LH`
- Update the brand aria label and browser title to match the new name

## Testing
- Not run; text-only branding update