### PR TITLE
Fix DigitalOcean deploy action input

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -37,4 +37,6 @@ jobs:
           SAMPLE_DIGEST: ${{ steps.push.outputs.digest }}
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-          app_id: ${{ secrets.DIGITALOCEAN_APP_ID }}
+          app_name: ${{ secrets.DIGITALOCEAN_APP_NAME }}
+          print_build_logs: true
+          print_deploy_logs: true


### PR DESCRIPTION
## Summary
- Replace unsupported `app_id` input with supported `app_name` for `digitalocean/app_action/deploy@v2`
- Read the app name from `DIGITALOCEAN_APP_NAME`
- Enable DigitalOcean build and deploy log output to make future failures easier to diagnose

## Why
The deploy action reports that `app_id` is not a valid input. The current v2 action accepts `app_name` or `app_spec_location` instead.

## Required setup
Add or update this GitHub repository secret before rerunning the workflow:

- `DIGITALOCEAN_APP_NAME`: the exact name of the existing DigitalOcean App Platform app

## Testing
- Not run; workflow configuration update only