### PR TITLE
Add Bengali voice selection to tutor

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -26,7 +26,7 @@ import YouTubeTranscript from "./components/youtube/YouTubeTranscript.jsx";
 import AppDrawers from "./layouts/AppDrawers.jsx";
 import ActionButtonStudio from "./pages/ActionButtonStudio.jsx";
 import ApiCheck from "./pages/ApiCheck.jsx";
-import BengaliTutor from "./pages/BengaliTutor.jsx";
+import BengaliTutorWithVoice from "./pages/BengaliTutorWithVoice.jsx";
 import ChatTemplate from "./pages/ChatTemplate.jsx";
 import CodingProblems from "./pages/CodingProblems.jsx";
 import CorrespondentBankingGuide from "./pages/CorrespondentBankingGuide.jsx";
@@ -127,7 +127,7 @@ function AppContent() {
           <Route path="/typingTest" element={<TypingTest />} />
           <Route path="/flashCards" element={<FlashCardApp />} />
           <Route path="/plantUML" element={<PlantUMLViewer />} />
-          <Route path="/bengali" element={<BengaliTutor />} />
+          <Route path="/bengali" element={<BengaliTutorWithVoice />} />
           <Route path="/coding" element={<CodingProblems />} />
           <Route path="/cpu-simulator" element={<Suspense fallback={null}><CpuSimulatorWithOutputHistory /></Suspense>} />
           <Route path="/system-design" element={<SystemDesignPrep />} />

--- a/frontend/src/pages/BengaliTutorWithVoice.jsx
+++ b/frontend/src/pages/BengaliTutorWithVoice.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import BengaliTutor from "./BengaliTutor.jsx";
 
 const VOICE_STORAGE_KEY = "bengali_tutor_voice";
@@ -14,6 +14,7 @@ const getSavedVoice = () => {
 export default function BengaliTutorWithVoice() {
   const [voices, setVoices] = useState([]);
   const [selectedVoiceName, setSelectedVoiceName] = useState(getSavedVoice);
+  const selectedVoiceRef = useRef(selectedVoiceName);
 
   useEffect(() => {
     if (typeof window === "undefined" || !window.speechSynthesis) return undefined;
@@ -34,10 +35,12 @@ export default function BengaliTutorWithVoice() {
 
   useEffect(() => {
     if (!selectedVoiceName || bengaliVoices.some((voice) => voice.name === selectedVoiceName)) return;
+    selectedVoiceRef.current = "";
     setSelectedVoiceName("");
   }, [bengaliVoices, selectedVoiceName]);
 
   useEffect(() => {
+    selectedVoiceRef.current = selectedVoiceName;
     try {
       if (selectedVoiceName) localStorage.setItem(VOICE_STORAGE_KEY, selectedVoiceName);
       else localStorage.removeItem(VOICE_STORAGE_KEY);
@@ -53,9 +56,10 @@ export default function BengaliTutorWithVoice() {
     const originalSpeak = synth.speak.bind(synth);
 
     const speakWithSelectedVoice = (utterance) => {
+      const voiceName = selectedVoiceRef.current;
       const isBengali = utterance?.lang?.toLowerCase().startsWith("bn");
-      if (isBengali && selectedVoiceName) {
-        const selectedVoice = synth.getVoices().find((voice) => voice.name === selectedVoiceName);
+      if (isBengali && voiceName) {
+        const selectedVoice = synth.getVoices().find((voice) => voice.name === voiceName);
         if (selectedVoice) voiceUtterance(utterance, selectedVoice);
       }
       originalSpeak(utterance);
@@ -74,10 +78,11 @@ export default function BengaliTutorWithVoice() {
         // The browser may expose speechSynthesis.speak as read-only.
       }
     };
-  }, [selectedVoiceName]);
+  }, []);
 
   const handleVoiceChange = (event) => {
     const voiceName = event.target.value;
+    selectedVoiceRef.current = voiceName;
     setSelectedVoiceName(voiceName);
 
     if (!voiceName || typeof window === "undefined" || !window.speechSynthesis) return;

--- a/frontend/src/pages/BengaliTutorWithVoice.jsx
+++ b/frontend/src/pages/BengaliTutorWithVoice.jsx
@@ -1,0 +1,157 @@
+import { useEffect, useMemo, useState } from "react";
+import BengaliTutor from "./BengaliTutor.jsx";
+
+const VOICE_STORAGE_KEY = "bengali_tutor_voice";
+
+const getSavedVoice = () => {
+  try {
+    return localStorage.getItem(VOICE_STORAGE_KEY) || "";
+  } catch {
+    return "";
+  }
+};
+
+export default function BengaliTutorWithVoice() {
+  const [voices, setVoices] = useState([]);
+  const [selectedVoiceName, setSelectedVoiceName] = useState(getSavedVoice);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.speechSynthesis) return undefined;
+
+    const synth = window.speechSynthesis;
+    const loadVoices = () => setVoices(synth.getVoices());
+
+    loadVoices();
+    synth.addEventListener?.("voiceschanged", loadVoices);
+
+    return () => synth.removeEventListener?.("voiceschanged", loadVoices);
+  }, []);
+
+  const bengaliVoices = useMemo(() => {
+    const matching = voices.filter((voice) => voice.lang?.toLowerCase().startsWith("bn"));
+    return matching.length ? matching : voices;
+  }, [voices]);
+
+  useEffect(() => {
+    if (!selectedVoiceName || bengaliVoices.some((voice) => voice.name === selectedVoiceName)) return;
+    setSelectedVoiceName("");
+  }, [bengaliVoices, selectedVoiceName]);
+
+  useEffect(() => {
+    try {
+      if (selectedVoiceName) localStorage.setItem(VOICE_STORAGE_KEY, selectedVoiceName);
+      else localStorage.removeItem(VOICE_STORAGE_KEY);
+    } catch {
+      // Local storage can be unavailable in private browsing contexts.
+    }
+  }, [selectedVoiceName]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.speechSynthesis) return undefined;
+
+    const synth = window.speechSynthesis;
+    const originalSpeak = synth.speak.bind(synth);
+
+    const speakWithSelectedVoice = (utterance) => {
+      const isBengali = utterance?.lang?.toLowerCase().startsWith("bn");
+      if (isBengali && selectedVoiceName) {
+        const selectedVoice = synth.getVoices().find((voice) => voice.name === selectedVoiceName);
+        if (selectedVoice) voiceUtterance(utterance, selectedVoice);
+      }
+      originalSpeak(utterance);
+    };
+
+    try {
+      synth.speak = speakWithSelectedVoice;
+    } catch {
+      return undefined;
+    }
+
+    return () => {
+      try {
+        synth.speak = originalSpeak;
+      } catch {
+        // The browser may expose speechSynthesis.speak as read-only.
+      }
+    };
+  }, [selectedVoiceName]);
+
+  const handleVoiceChange = (event) => {
+    const voiceName = event.target.value;
+    setSelectedVoiceName(voiceName);
+
+    if (!voiceName || typeof window === "undefined" || !window.speechSynthesis) return;
+    const voice = window.speechSynthesis.getVoices().find((item) => item.name === voiceName);
+    if (!voice) return;
+
+    const preview = new SpeechSynthesisUtterance("স্বাগতম");
+    preview.lang = voice.lang || "bn-BD";
+    voiceUtterance(preview, voice);
+    window.speechSynthesis.cancel();
+    window.speechSynthesis.speak(preview);
+  };
+
+  return (
+    <>
+      <section style={styles.voicePanel} aria-label="Bengali voice settings">
+        <label style={styles.label} htmlFor="bengali-voice-select">
+          Bengali voice
+        </label>
+        <select
+          id="bengali-voice-select"
+          value={selectedVoiceName}
+          onChange={handleVoiceChange}
+          style={styles.select}
+        >
+          <option value="">System default</option>
+          {bengaliVoices.map((voice) => (
+            <option key={`${voice.name}-${voice.lang}`} value={voice.name}>
+              {voice.name} ({voice.lang})
+            </option>
+          ))}
+        </select>
+        <span style={styles.helpText}>
+          The selected voice is used for Bengali pronunciation throughout the tutor.
+        </span>
+      </section>
+      <BengaliTutor />
+    </>
+  );
+}
+
+const voiceUtterance = (utterance, voice) => {
+  utterance.voice = voice;
+  utterance.lang = voice.lang || "bn-BD";
+};
+
+const styles = {
+  voicePanel: {
+    width: "min(100% - 2rem, 1100px)",
+    margin: "1rem auto 0",
+    padding: "0.9rem 1rem",
+    display: "grid",
+    gap: "0.45rem",
+    border: "1px solid #dbe3ef",
+    borderRadius: "14px",
+    background: "#ffffff",
+    boxShadow: "0 10px 24px rgba(15, 23, 42, 0.08)",
+  },
+  label: {
+    color: "#0f172a",
+    fontWeight: 800,
+  },
+  select: {
+    width: "100%",
+    minHeight: "44px",
+    padding: "0.65rem 0.75rem",
+    border: "1px solid #cbd5e1",
+    borderRadius: "10px",
+    background: "#ffffff",
+    color: "#0f172a",
+    fontWeight: 700,
+  },
+  helpText: {
+    color: "#64748b",
+    fontSize: "0.88rem",
+  },
+};


### PR DESCRIPTION
## What changed
- Added a Bengali voice dropdown above the Bengali tutor.
- Loads available browser speech-synthesis voices and prioritizes Bengali-language voices.
- Applies the selected voice to Bengali pronunciation throughout the tutor.
- Previews the chosen voice with a Bengali sample.
- Persists the selection in local storage.
- Falls back to the system default voice when no voice is selected.

## Implementation notes
- Added `BengaliTutorWithVoice.jsx` as a focused wrapper around the existing tutor.
- Updated the `/bengali` route to use the voice-enabled wrapper.
- The existing Bengali tutor logic remains unchanged.

## Validation
- Reviewed the branch diff and verified the route imports and component wiring.
- Browser voice availability is device-dependent, so the selector gracefully falls back to all installed voices when no `bn-*` voice is reported.